### PR TITLE
Migrate plugin to npe2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,8 +16,8 @@ requires-python = ">=3.6"
 requires = ['numpy', 'pyvideoreader']
 description-file = "README.md"
 
-[tool.flit.entrypoints."napari.plugin"]
-video = "napari_video.napari_video"
+[tool.flit.entrypoints."napari.manifest"]
+napari_video = "napari_video:napari.yaml"
 
 [tool.flit.metadata.urls]
 "Bug Tracker" = "https://github.com/janclemenslab/napari-video/issues"

--- a/setup.py
+++ b/setup.py
@@ -42,5 +42,5 @@ setup(name='napari_video',
       install_requires=['numpy', 'pyvideoreader'],
       include_package_data=True,
       zip_safe=False,
-      entry_points={'napari.plugin': 'video = napari_video.napari_video'},
+      entry_points={'napari.manifest': 'napari_video = napari_video:napari.yaml'},
      )

--- a/src/napari_video/napari.yaml
+++ b/src/napari_video/napari.yaml
@@ -1,0 +1,11 @@
+name: napari_video
+display_name: video
+contributions:
+  commands:
+  - id: napari_video.get_reader
+    title: Read video files
+    python_name: napari_video.napari_video:napari_get_reader
+  readers:
+  - command: napari_video.get_reader
+    filename_patterns: ["*.mp4", "*.mov", "*.avi"]
+    accepts_directories: false

--- a/src/napari_video/napari_video.py
+++ b/src/napari_video/napari_video.py
@@ -1,6 +1,5 @@
 import numpy as np
 from videoreader import VideoReader
-from napari_plugin_engine import napari_hook_implementation
 import cv2
 
 
@@ -85,7 +84,6 @@ def video_file_reader(path):
     return [(array, {'name': path}, 'image')]
 
 
-@napari_hook_implementation
 def napari_get_reader(path):
     # remember, path can be a list, so we check it's type first...
     if isinstance(path, str) and any([path.endswith(ext) for ext in [".mp4", ".mov", ".avi"]]):


### PR DESCRIPTION
This PR closes #4 by migrating the plugin to `npe2` by:
- adding a `napari.yaml` manifest file;
- adding the `napari.manifest` entry point to both `pyproject.toml` and `setup.py` (replaces the older `napari.plugin` entry point);
- removing the `@napari_hook_implementation` decorator, as it's no longer needed.

I've confirmed that the new configuration works locally via:
```bash
pip install -e .
npe2 validate napari_video
```

I also launched `napari` locally and loaded several videos into it, using the plugin. It seems to work exactly the same as before (but without the warning for `npe2` migration of course).

Do test if it works for you too @postpop and let me know.